### PR TITLE
feat: allow user to specify repo path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,88 @@
+use std::error::Error;
+use git2::Repository;
+
+pub mod providers;
+pub mod git_analysis;
+pub mod git;
+pub mod ui;
+pub mod modes;
+
+#[derive(Debug)]
+pub struct Config {
+    model: Box<dyn git_analysis::GitAnalyzer>,
+    repo_path: String,
+}
+
+#[derive(Debug)]
+pub struct FileAnalysis {
+    pub path: String,
+    pub explanation: String,
+}
+
+impl Config {
+    pub fn new(model: Box<dyn git_analysis::GitAnalyzer>, repo_path: Option<String>) -> Self {
+        Self { 
+            model,
+            repo_path: repo_path.unwrap_or_else(|| ".".to_string())
+        }
+    }
+
+    pub async fn generate_commit_message(&self, diff: &str) -> Result<String, Box<dyn Error>> {
+        self.model.generate_commit_message(diff).await
+    }
+
+    pub async fn analyze_changes(&self, repo: &Repository) -> Result<Vec<FileAnalysis>, Box<dyn Error>> {
+        let file_diffs = git::get_file_diffs(repo)?;
+        
+        let analysis_futures: Vec<_> = file_diffs.into_iter().map(|(path, diff)| {
+            let model = &self.model;
+            async move {
+                let explanation = model.analyze_file_changes(&diff).await?;
+                Ok::<FileAnalysis, Box<dyn Error>>(FileAnalysis {
+                    path,
+                    explanation,
+                })
+            }
+        }).collect();
+
+        futures::future::join_all(analysis_futures)
+            .await
+            .into_iter()
+            .collect()
+    }
+
+    pub async fn analyze_contributor(&self, stats: &str) -> Result<String, Box<dyn Error>> {
+        self.model.analyze_contributor(stats).await
+    }
+}
+
+pub async fn run(_repo_path: Option<String>) -> Result<(), Box<dyn Error>> {
+    let repo_path = loop {
+        let path = ui::get_repository_path(".")?;
+        match Repository::open(&path) {
+            Ok(_) => break path,
+            Err(_) => println!("Invalid git repository path. Please try again."),
+        }
+    };
+
+    let config = {
+        let providers = providers::get_available_providers();
+        let selected_idx = providers::select_provider(&providers)?;
+        Config::new(git_analysis::wrap_provider(providers.into_iter().nth(selected_idx).unwrap()), Some(repo_path))
+    };
+    
+    let repo = Repository::open(&config.repo_path)?;
+
+    loop {
+        let mode = ui::select_mode().await?;
+        mode.execute(&config, &repo).await?;
+
+        let options = ["✨ Do something else", "❌ Exit"];
+        if ui::show_selection_menu("What would you like to do next?", &options, 0)? == 1 {
+            break;
+        }
+        println!("\x1B[2J\x1B[1;1H"); // Clear screen
+    }
+    
+    Ok(())
+} 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,28 +1,11 @@
-use std::error::Error;
-
-pub mod providers;
-pub mod ui;
-pub mod modes;
+use dotenv;
+use merit_cli_demo::run;
+use std::env;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv::dotenv().ok();
-
-    let providers = providers::get_available_providers();
-
-    println!("Available providers:");
-    for (i, provider) in providers.iter().enumerate() {
-        println!("{}: {}", i, provider.name());
-    }
-
-    let selected_idx = providers::select_provider(&providers)?;
-    let provider = &providers[selected_idx];
-
-    println!("Selected provider: {}", provider.name());
-
-    let mode = ui::select_mode().await?;
-
-    println!("Selected mode: {}", mode.description());
-
-    Ok(())
+    
+    let repo_path = env::args().nth(1);
+    run(repo_path).await
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use dialoguer::{theme::ColorfulTheme, Select};
+use dialoguer::{theme::ColorfulTheme, Select, Input};
 use indicatif::{ProgressBar, ProgressStyle};
 
 use crate::modes::Mode;
@@ -38,4 +38,13 @@ pub async fn select_mode() -> Result<Mode, Box<dyn Error>> {
         1 => Mode::FileAnalysis,
         _ => Mode::ContributorAnalysis,
     })
+}
+
+pub fn get_repository_path(default: &str) -> Result<String, Box<dyn Error>> {
+    let path: String = Input::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter repository path")
+        .default(default.into())
+        .allow_empty(true)
+        .interact()?;
+    Ok(if path.is_empty() { ".".to_string() } else { path })
 }


### PR DESCRIPTION
Allow a user to point the CLI tool at an repository on their machine rather than always using the current repo.
<img width="191" alt="image" src="https://github.com/user-attachments/assets/9e0f4d2b-2bb0-4eac-8510-bb265691b497" />
